### PR TITLE
remove elixir 1.4, 1.5

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-declare -a -r versions=( 1.11 1.10 1.9 1.8 1.7 1.6 1.5 1.4 )
+declare -a -r versions=( 1.11 1.10 1.9 1.8 1.7 1.6 )
 declare -A -r aliases=(
 	[1.11]='latest'
 )
@@ -87,7 +87,7 @@ for version in "${versions[@]}"; do
 		variantArches=( amd64 arm32v7 arm64v8 i386 s390x ppc64le )
 
 		case "$version" in
-			1.[87654])
+			1.[876])
                 variantArches=( ${variantArches[@]/ppc64le} )
                 variantArches=( ${variantArches[@]/s390x} )
 		esac


### PR DESCRIPTION
As in docker-library/official-images#8979 ,  and https://hexdocs.pm/elixir/compatibility-and-deprecations.html
remove elixir 1.4, 1.5 