### PR TITLE
Include only Elixir lib folder, not binaries or hidden files

### DIFF
--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -13,6 +13,8 @@ RUN set -xe \
 	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
 	&& rm elixir-src.tar.gz \
 	&& cd /usr/local/src/elixir \
-	&& make install clean
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
 
 CMD ["iex"]

--- a/1.12/alpine/Dockerfile
+++ b/1.12/alpine/Dockerfile
@@ -20,6 +20,8 @@ RUN set -xe \
 	&& rm elixir-src.tar.gz \
 	&& cd /usr/local/src/elixir \
 	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
 	&& apk del .build-deps
 
 CMD ["iex"]

--- a/1.12/slim/Dockerfile
+++ b/1.12/slim/Dockerfile
@@ -21,6 +21,8 @@ RUN set -xe \
 	&& rm elixir-src.tar.gz \
 	&& cd /usr/local/src/elixir \
 	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Partially fixes https://github.com/erlef/docker-elixir/issues/13.

It looks like elixir docker image includes the entire copy of git repo:
![image](https://user-images.githubusercontent.com/4661021/120405251-d0094300-c350-11eb-814f-0a9f8a8bfb1c.png)

It is OK for `lib` folder because it is important to have Elixir sources for compiling some modules. But there should be no files or folders like `.github`, `.cirrus.yaml`, as well as `test` dirs.