### PR TITLE
Bump Elixir to v1.12.3

### DIFF
--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.12.2" \
+ENV ELIXIR_VERSION="v1.12.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="701006d1279225fc42f15c8d3f39906db127ddcc95373d34d8d160993356b15c" \
+	&& ELIXIR_DOWNLOAD_SHA256="c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.12/alpine/Dockerfile
+++ b/1.12/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.12.2" \
+ENV ELIXIR_VERSION="v1.12.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="701006d1279225fc42f15c8d3f39906db127ddcc95373d34d8d160993356b15c" \
+	&& ELIXIR_DOWNLOAD_SHA256="c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.12/slim/Dockerfile
+++ b/1.12/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.12.2" \
+ENV ELIXIR_VERSION="v1.12.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="701006d1279225fc42f15c8d3f39906db127ddcc95373d34d8d160993356b15c" \
+	&& ELIXIR_DOWNLOAD_SHA256="c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
💁 These changes update the Elixir 1.12 version stream to 1.12.3.