### PR TITLE
New image to support OTP-24 with elixir 1.14

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine',
+        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine',
               'DIR=1.13', 'DIR=1.13 VARIANT=slim', 'DIR=1.13 VARIANT=alpine', 'DIR=1.13 VARIANT=otp-25', 'DIR=1.13 VARIANT=otp-25-slim', 'DIR=1.13 VARIANT=otp-25-alpine',
               'DIR=1.12', 'DIR=1.12 VARIANT=slim', 'DIR=1.12 VARIANT=alpine',
               'DIR=1.11', 'DIR=1.11 VARIANT=slim', 'DIR=1.11 VARIANT=alpine',

--- a/1.14/otp-24-alpine/Dockerfile
+++ b/1.14/otp-24-alpine/Dockerfile
@@ -1,0 +1,27 @@
+FROM erlang:24-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.1" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.14/otp-24-slim/Dockerfile
+++ b/1.14/otp-24-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM erlang:24-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.1" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/1.14/otp-24/Dockerfile
+++ b/1.14/otp-24/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:24
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.1" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
+
+CMD ["iex"]


### PR DESCRIPTION
Since elixir 1.14 is compatible with OTP-24, it might be useful to have an image supporting this combination.
See #53 
Maybe I forgot something here..? 🙂