### PR TITLE
Fix unmatched docker image version

### DIFF
--- a/1.14/otp-24-alpine/Dockerfile
+++ b/1.14/otp-24-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.1" \
+ENV ELIXIR_VERSION="v1.14.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& ELIXIR_DOWNLOAD_SHA256="3f79e384706495725119f60982fa16ea82d510c3fbeacfc6ee1a77c792bf152a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.14/otp-24-slim/Dockerfile
+++ b/1.14/otp-24-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.1" \
+ENV ELIXIR_VERSION="v1.14.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& ELIXIR_DOWNLOAD_SHA256="3f79e384706495725119f60982fa16ea82d510c3fbeacfc6ee1a77c792bf152a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.14/otp-24/Dockerfile
+++ b/1.14/otp-24/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.1" \
+ENV ELIXIR_VERSION="v1.14.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="8ad537eb84471c24c3e6984c37884f06a7834ff2efd72c436c222baee8df9a11" \
+	&& ELIXIR_DOWNLOAD_SHA256="3f79e384706495725119f60982fa16ea82d510c3fbeacfc6ee1a77c792bf152a" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \


### PR DESCRIPTION
The images of tag `1.14.2-otp-24*` didn't match the actual elixir version in it:

```
$ podman run -it --rm docker.io/library/elixir:1.14.2-otp-24-slim elixir --version
Erlang/OTP 24 [erts-12.3.2.6] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit]

Elixir 1.14.1 (compiled with Erlang/OTP 24)
```

