### PR TITLE
Add OTP25 support for v1.14

### DIFF
--- a/1.14/otp-25-alpine/Dockerfile
+++ b/1.14/otp-25-alpine/Dockerfile
@@ -1,0 +1,27 @@
+FROM erlang:25-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.4" \
+    LANG=C.UTF-8
+
+RUN set -xe \
+    && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+    && ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
+    && buildDeps=' \
+    ca-certificates \
+    curl \
+    make \
+    ' \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+    && echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/local/src/elixir \
+    && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+    && rm elixir-src.tar.gz \
+    && cd /usr/local/src/elixir \
+    && make install clean \
+    && find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+    && find /usr/local/src/elixir/ -type d -depth -empty -delete \
+    && apk del .build-deps
+
+CMD ["iex"]

--- a/1.14/otp-25-slim/Dockerfile
+++ b/1.14/otp-25-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM erlang:25-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.4" \
+    LANG=C.UTF-8
+
+RUN set -xe \
+    && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+    && ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
+    && buildDeps=' \
+    ca-certificates \
+    curl \
+    make \
+    ' \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+    && echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/local/src/elixir \
+    && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+    && rm elixir-src.tar.gz \
+    && cd /usr/local/src/elixir \
+    && make install clean \
+    && find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+    && find /usr/local/src/elixir/ -type d -depth -empty -delete \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/1.14/otp-25/Dockerfile
+++ b/1.14/otp-25/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:25
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.14.4" \
+    LANG=C.UTF-8
+
+RUN set -xe \
+    && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+    && ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
+    && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+    && echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/local/src/elixir \
+    && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+    && rm elixir-src.tar.gz \
+    && cd /usr/local/src/elixir \
+    && make install clean \
+    && find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+    && find /usr/local/src/elixir/ -type d -depth -empty -delete
+
+CMD ["iex"]


### PR DESCRIPTION
- Adds OTP25 support for v1.14 images

I pushed this to https://hub.docker.com/layers/kartstig/elixir/1.14.4-otp-25/images/sha256-46266b1d21b3533231a1e705027ef1aef29fcf6267e99544ab93c826d19ce31f?context=repo