### PR TITLE
Support elixir v1.14.5 and OTP 26

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-25', 'DIR=1.14 VARIANT=otp-25-slim', 'DIR=1.14 VARIANT=otp-25-alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine'
+        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-25', 'DIR=1.14 VARIANT=otp-25-slim', 'DIR=1.14 VARIANT=otp-25-alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine',
               'DIR=1.13', 'DIR=1.13 VARIANT=slim', 'DIR=1.13 VARIANT=alpine', 'DIR=1.13 VARIANT=otp-23-slim', 'DIR=1.13 VARIANT=otp-25', 'DIR=1.13 VARIANT=otp-25-slim', 'DIR=1.13 VARIANT=otp-25-alpine',
               'DIR=1.12', 'DIR=1.12 VARIANT=slim', 'DIR=1.12 VARIANT=alpine',
               'DIR=1.11', 'DIR=1.11 VARIANT=slim', 'DIR=1.11 VARIANT=alpine',

--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine',
+        elixir: ['DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-25', 'DIR=1.14 VARIANT=otp-25-slim', 'DIR=1.14 VARIANT=otp-25-alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine'
               'DIR=1.13', 'DIR=1.13 VARIANT=slim', 'DIR=1.13 VARIANT=alpine', 'DIR=1.13 VARIANT=otp-23-slim', 'DIR=1.13 VARIANT=otp-25', 'DIR=1.13 VARIANT=otp-25-slim', 'DIR=1.13 VARIANT=otp-25-alpine',
               'DIR=1.12', 'DIR=1.12 VARIANT=slim', 'DIR=1.12 VARIANT=alpine',
               'DIR=1.11', 'DIR=1.11 VARIANT=slim', 'DIR=1.11 VARIANT=alpine',

--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -1,12 +1,12 @@
-FROM erlang:25
+FROM erlang:26
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.4" \
+ENV ELIXIR_VERSION="v1.14.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
+	&& ELIXIR_DOWNLOAD_SHA256="2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.14/alpine/Dockerfile
+++ b/1.14/alpine/Dockerfile
@@ -1,12 +1,12 @@
-FROM erlang:25-alpine
+FROM erlang:26-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.4" \
+ENV ELIXIR_VERSION="v1.14.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
+	&& ELIXIR_DOWNLOAD_SHA256="2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.14/otp-25-alpine/Dockerfile
+++ b/1.14/otp-25-alpine/Dockerfile
@@ -1,19 +1,18 @@
-FROM erlang:26-slim
+FROM erlang:25-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.5" \
+ENV ELIXIR_VERSION="v1.14.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd" \
+	&& ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \
 		make \
 	' \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \
@@ -23,7 +22,6 @@ RUN set -xe \
 	&& make install clean \
 	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
 	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apk del .build-deps
 
 CMD ["iex"]

--- a/1.14/otp-25-slim/Dockerfile
+++ b/1.14/otp-25-slim/Dockerfile
@@ -1,12 +1,12 @@
-FROM erlang:26-slim
+FROM erlang:25-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.5" \
+ENV ELIXIR_VERSION="v1.14.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd" \
+	&& ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.14/otp-25/Dockerfile
+++ b/1.14/otp-25/Dockerfile
@@ -1,19 +1,12 @@
-FROM erlang:26-slim
+FROM erlang:25
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.14.5" \
+ENV ELIXIR_VERSION="v1.14.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd" \
-	&& buildDeps=' \
-		ca-certificates \
-		curl \
-		make \
-	' \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& ELIXIR_DOWNLOAD_SHA256="07d66cf147acadc21bd1679f486efd6f8d64a73856ecc83c71b5e903081b45d2" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \
@@ -22,8 +15,6 @@ RUN set -xe \
 	&& cd /usr/local/src/elixir \
 	&& make install clean \
 	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
-	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& rm -rf /var/lib/apt/lists/*
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
 
 CMD ["iex"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -72,7 +72,7 @@ for version in "${versions[@]}"; do
 	done
 	versionAliases+=( $version ${aliases[$version]:-} )
 
-	for variant in '' slim alpine otp-23-slim otp-24 otp-24-alpine otp-24-slim otp-{21,22,25}{,-alpine,-slim}; do
+	for variant in '' slim alpine otp-23-slim otp-{21,22,24,25}{,-alpine,-slim}; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue
 


### PR DESCRIPTION
- Supports https://www.erlang.org/blog/otp-26-highlights/
- Use `erlang/OTP 26` as a base image in `1.14.5` but still supports `erlang/OTP 25` just like `erlang/OTP 24` directory structure
- note: OTP 25 and 24 still uses `1.14.4`, if we want to upgrade let me know I can upgrade here or in another follow up PR 

Elixir have basic supports of erlang/OTP 26 see:
- https://hexdocs.pm/elixir/1.14.4/changelog.html#v1-14-4-2023-04-03
- https://hexdocs.pm/elixir/1.14.5/changelog.html#v1-14-5-2023-05-22

@getong let me know if this is a good idea, and let me know if we're ready for this
