### PR TITLE
elixir v1.15.0

### DIFF
--- a/1.15/Dockerfile
+++ b/1.15/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.15/alpine/Dockerfile
+++ b/1.15/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.15/otp-24-alpine/Dockerfile
+++ b/1.15/otp-24-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.15/otp-24-slim/Dockerfile
+++ b/1.15/otp-24-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.15/otp-24/Dockerfile
+++ b/1.15/otp-24/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:24
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.15/otp-25-alpine/Dockerfile
+++ b/1.15/otp-25-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.15/otp-25-slim/Dockerfile
+++ b/1.15/otp-25-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.15/otp-25/Dockerfile
+++ b/1.15/otp-25/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.15/slim/Dockerfile
+++ b/1.15/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.15.0-rc.2" \
+ENV ELIXIR_VERSION="v1.15.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9ba0153d0edac70d00c8f7cf2758030f744626c59f0950ac1fb4a36c2ecd4af9" \
+	&& ELIXIR_DOWNLOAD_SHA256="0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -eu
 
 declare -a -r versions=(1.15 1.14 1.13 1.12 1.11 1.10 1.9 1.8 1.7 )
 declare -A -r aliases=(
-	[1.14]='latest'
+	[1.15]='latest'
 )
 
 # get the most recent commit which modified any of "$@"


### PR DESCRIPTION
- Supports elixir `v1.15.0` https://github.com/elixir-lang/elixir/releases/tag/v1.15.0