### PR TITLE
add elixir 1.16.0

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['DIR=1.15', 'DIR=1.15 VARIANT=slim', 'DIR=1.15 VARIANT=alpine', 'DIR=1.15 VARIANT=otp-25', 'DIR=1.15 VARIANT=otp-25-slim', 'DIR=1.15 VARIANT=otp-25-alpine', 'DIR=1.15 VARIANT=otp-24', 'DIR=1.15 VARIANT=otp-24-slim', 'DIR=1.15 VARIANT=otp-24-alpine',
+        elixir: ['DIR=1.16', 'DIR=1.16 VARIANT=slim', 'DIR=1.16 VARIANT=alpine', 'DIR=1.16 VARIANT=otp-25', 'DIR=1.16 VARIANT=otp-25-slim', 'DIR=1.16 VARIANT=otp-25-alpine', 'DIR=1.16 VARIANT=otp-24', 'DIR=1.16 VARIANT=otp-24-slim', 'DIR=1.16 VARIANT=otp-24-alpine',
+              'DIR=1.15', 'DIR=1.15 VARIANT=slim', 'DIR=1.15 VARIANT=alpine', 'DIR=1.15 VARIANT=otp-25', 'DIR=1.15 VARIANT=otp-25-slim', 'DIR=1.15 VARIANT=otp-25-alpine', 'DIR=1.15 VARIANT=otp-24', 'DIR=1.15 VARIANT=otp-24-slim', 'DIR=1.15 VARIANT=otp-24-alpine',
               'DIR=1.14', 'DIR=1.14 VARIANT=slim', 'DIR=1.14 VARIANT=alpine', 'DIR=1.14 VARIANT=otp-25', 'DIR=1.14 VARIANT=otp-25-slim', 'DIR=1.14 VARIANT=otp-25-alpine', 'DIR=1.14 VARIANT=otp-24', 'DIR=1.14 VARIANT=otp-24-slim', 'DIR=1.14 VARIANT=otp-24-alpine',
               'DIR=1.13', 'DIR=1.13 VARIANT=slim', 'DIR=1.13 VARIANT=alpine', 'DIR=1.13 VARIANT=otp-23-slim', 'DIR=1.13 VARIANT=otp-25', 'DIR=1.13 VARIANT=otp-25-slim', 'DIR=1.13 VARIANT=otp-25-alpine',
               'DIR=1.12', 'DIR=1.12 VARIANT=slim', 'DIR=1.12 VARIANT=alpine',

--- a/1.16/Dockerfile
+++ b/1.16/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:26
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
+
+CMD ["iex"]

--- a/1.16/alpine/Dockerfile
+++ b/1.16/alpine/Dockerfile
@@ -1,0 +1,27 @@
+FROM erlang:26-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.16/otp-24-alpine/Dockerfile
+++ b/1.16/otp-24-alpine/Dockerfile
@@ -1,0 +1,27 @@
+FROM erlang:24-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.16/otp-24-slim/Dockerfile
+++ b/1.16/otp-24-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM erlang:24-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/1.16/otp-24/Dockerfile
+++ b/1.16/otp-24/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:24
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
+
+CMD ["iex"]

--- a/1.16/otp-25-alpine/Dockerfile
+++ b/1.16/otp-25-alpine/Dockerfile
@@ -1,0 +1,27 @@
+FROM erlang:25-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.16/otp-25-slim/Dockerfile
+++ b/1.16/otp-25-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM erlang:25-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/1.16/otp-25/Dockerfile
+++ b/1.16/otp-25/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:25
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete
+
+CMD ["iex"]

--- a/1.16/slim/Dockerfile
+++ b/1.16/slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM erlang:26-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.16.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="d7fe641e3c85c9774232618d22c880c86c2f31e3508c344ce75d134cd40aea18" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu
 
-declare -a -r versions=(1.15 1.14 1.13 1.12 1.11 1.10 1.9 1.8 1.7 )
+declare -a -r versions=(1.16 1.15 1.14 1.13 1.12 1.11 1.10 1.9 1.8 1.7 )
 declare -A -r aliases=(
-	[1.15]='latest'
+	[1.16]='latest'
 )
 
 # get the most recent commit which modified any of "$@"


### PR DESCRIPTION
I've added Elixir 1.16.0 (c.f. <https://elixir-lang.org/blog/2023/12/22/elixir-v1-16-0-released/> ) to the buildout.