### PR TITLE
Adjust `generate-stackbrew-library.sh` to only list upstream-supported versions

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -eu
 
-declare -a -r versions=(1.16 1.15 1.14 1.13 1.12 1.11 1.10 1.9 1.8 1.7 )
+declare -a -r versions=(
+	# https://github.com/elixir-lang/elixir/blob/main/SECURITY.md#supported-versions
+	1.16
+	1.15
+	1.14
+	1.13
+	1.12
+)
 declare -A -r aliases=(
 	[1.16]='latest'
 )


### PR DESCRIPTION
See https://github.com/elixir-lang/elixir/blob/14895c98f30a708661e2176c90512a63a276a5e5/SECURITY.md#supported-versions for the (current) list of upstream supported versions (1.12 through 1.16).

https://github.com/docker-library/official-images/pull/15967#issuecomment-1868443368

> As a reminder, removing tags here will remove them from the "Supported" section on the Hub readme (and will prevent us from spending cycles rebuilding them on the official build servers), but the tags will still be available to users who want them. (See https://github.com/docker-library/official-images#library-definition-files for more detail on this.)