### PR TITLE
Remove the image layer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # About this Repo
 
+[![Build Status](https://github.com/erlef/docker-elixir/workflows/elixir/badge.svg)](https://github.com/erlef/docker-elixir/actions)
 [![Docker Stars](https://img.shields.io/docker/stars/_/elixir.svg?style=flat-square)](https://hub.docker.com/_/elixir/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/_/elixir.svg?style=flat-square)](https://hub.docker.com/_/elixir/)
-[![Image Layers](https://images.microbadger.com/badges/image/elixir.svg)](https://microbadger.com/images/elixir "Get your own image badge on microbadger.com")
-
-[![Build Status](https://github.com/erlef/docker-elixir/workflows/elixir/badge.svg)](https://github.com/erlef/docker-elixir/actions)
 
 This is for elixir latest stable image and next -dev image.
 


### PR DESCRIPTION
The badge have been deprecated and returning 404.