### PR TITLE
Elixir v1.18.4

### DIFF
--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.18/alpine/Dockerfile
+++ b/1.18/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.18/otp-25-alpine/Dockerfile
+++ b/1.18/otp-25-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.18/otp-25-slim/Dockerfile
+++ b/1.18/otp-25-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.18/otp-25/Dockerfile
+++ b/1.18/otp-25/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:25
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.18/otp-26-alpine/Dockerfile
+++ b/1.18/otp-26-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.18/otp-26-slim/Dockerfile
+++ b/1.18/otp-26-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.18/otp-26/Dockerfile
+++ b/1.18/otp-26/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.18/slim/Dockerfile
+++ b/1.18/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.18.3" \
+ENV ELIXIR_VERSION="v1.18.4" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="f8d4376311058dd9a78ed365fa1df9fd1b22d2468c587e3f0f4fb320283a1ed7" \
+	&& ELIXIR_DOWNLOAD_SHA256="8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Not sure if this is the correct procedure. I replicated what was done in commit [263d517](https://github.com/erlef/docker-elixir/commit/263d517a95ebbe6671717ef28b5ccccc9360436d).

For the sha256 checksum, I downloaded the `tar.gz` file from the github repository and calculated the checksum locally on my machine with `sha256sum` command.

I tested it, and I was able to successfully build the main `Dockerfile`.