### PR TITLE
Bump to 1.19.5

### DIFF
--- a/1.19/Dockerfile
+++ b/1.19/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.19/alpine/Dockerfile
+++ b/1.19/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.19/otp-26-alpine/Dockerfile
+++ b/1.19/otp-26-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.19/otp-26-slim/Dockerfile
+++ b/1.19/otp-26-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.19/otp-26/Dockerfile
+++ b/1.19/otp-26/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:26
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.19/otp-27-alpine/Dockerfile
+++ b/1.19/otp-27-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.19/otp-27-slim/Dockerfile
+++ b/1.19/otp-27-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.19/otp-27/Dockerfile
+++ b/1.19/otp-27/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.19/slim/Dockerfile
+++ b/1.19/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.19.4" \
+ENV ELIXIR_VERSION="v1.19.5" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="a2df9d5411fc53d97ec17c069765c8fb781f8dc36c4e06ec1cd4b189340d364b" \
+	&& ELIXIR_DOWNLOAD_SHA256="10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Configures `ELIXIR_VERSION` and `ELIXIR_DOWNLOAD_SHA256` to support Elixir 1.19.5 across OTP 26-28. 