### PR TITLE
Bump Elixir to v1.20.1

### DIFF
--- a/1.20/Dockerfile
+++ b/1.20/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/alpine/Dockerfile
+++ b/1.20/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27-alpine/Dockerfile
+++ b/1.20/otp-27-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27-slim/Dockerfile
+++ b/1.20/otp-27-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27/Dockerfile
+++ b/1.20/otp-27/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/otp-28-alpine/Dockerfile
+++ b/1.20/otp-28-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-28-slim/Dockerfile
+++ b/1.20/otp-28-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-28/Dockerfile
+++ b/1.20/otp-28/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/slim/Dockerfile
+++ b/1.20/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.0" \
+ENV ELIXIR_VERSION="v1.20.1" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="70f6cb721f238fa5dd33eb29aa5b19e5ccc3807e41cd5f9b65d5c715b669438c" \
+	&& ELIXIR_DOWNLOAD_SHA256="baed8756da722c1b8d71613655c7223ab952051bc391a965cd79e320a93aaf77" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Configures ELIXIR_VERSION and ELIXIR_DOWNLOAD_SHA256 to support Elixir 1.20.1 across OTP 27-29.