### PR TITLE
Bump Elixir to 1.20.3

### DIFF
--- a/1.20/Dockerfile
+++ b/1.20/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/alpine/Dockerfile
+++ b/1.20/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27-alpine/Dockerfile
+++ b/1.20/otp-27-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27-slim/Dockerfile
+++ b/1.20/otp-27-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-27/Dockerfile
+++ b/1.20/otp-27/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:27
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/otp-28-alpine/Dockerfile
+++ b/1.20/otp-28-alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-28-slim/Dockerfile
+++ b/1.20/otp-28-slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.20/otp-28/Dockerfile
+++ b/1.20/otp-28/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:28
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.20/slim/Dockerfile
+++ b/1.20/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:29-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.20.2" \
+ENV ELIXIR_VERSION="v1.20.3" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0" \
+	&& ELIXIR_DOWNLOAD_SHA256="ff22a894b130631443db1a193b4e8cb4762f697128566e43da848fd16c3777bd" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Bump all Elixir versions in every Dockerfile under 1.20 to 1.20.3 